### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+PREFIX := /usr/local
+DESTINATION = ${DESTDIR}${PREFIX}/bin
+
+all:
+
+install: ${DESTINATION}
+	install rofi-jack-connect ${DESTINATION}
+	install rofi-jack-device ${DESTINATION}
+
+${DESTINATION}:
+	mkdir -p ${DESTINATION}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@
 
 A collection of scripts for controlling and manipulating the [JACK audio connection kit](https://jackaudio.org/) using the [rofi](https://github.com/davatorium/rofi) application launcher.
 
+# Installation
+To install to default path (under /usr/local) run the following:
+```
+make install
+```
+
+As most Linux distributions use /usr as their prefix, to install under /usr
+run the following:
+```
+make PREFIX=/usr install
+```
+
+For packaging purposes the `DESTDIR` is also supported
+```
+make PREFIX=/usr DESTDIR=/tmp/rofi-jack install
+```
+
 # Scripts
 
 ### rofi-jack-device


### PR DESCRIPTION
To install in `/usr/bin` one would run `make PREFIX=/usr install`. Just running `make install` uses `/usr/local` as prefix by default. I added `all:` target because first target is default one when running `make` without arguments. I tried bsdmake and gnumake, so I hope this works for you, too.